### PR TITLE
Fix/21 remove test deprecation warning

### DIFF
--- a/murphy/parsegtf.py
+++ b/murphy/parsegtf.py
@@ -20,7 +20,9 @@ place a gtf file or bed file into the interval overlap tree.
 # 2017-01-05	S. Stiegelmeyer	Add some comments
 # 2017-07-15    C. Calloway     Flake8
 # 2017-07-15    S. Stiegelmeyer Add document strings
+# 2017-07-19    C. Calloway     Sixify
 
+import six
 import numpy
 import matplotlib.pyplot
 
@@ -29,6 +31,11 @@ from murphy.Tree import intervalTree
 
 matplotlib.style.use('ggplot')
 
+def openru(f):
+    if six.PY2:
+        return open(f, "rU")
+    else:
+        return open(f, newline=None)
 
 def getKeySort(item):
     '''
@@ -78,7 +85,7 @@ def makeExonIntronTree(gtf, pchrom):
         dictionary of interval trees where the key is the chromosome and the
         value is the root of the interval tree
     '''
-    gfh = open(gtf, "rU")
+    gfh = openru(gtf)
     genes = {}
     for line in gfh:
         fields = line.strip().split('\t')
@@ -160,7 +167,7 @@ def makeExonIntronTreePos(gtf, pchrom):
             first - coordinate of 5' end of first exon or intron
             last - coordinate of 3' end of last exon or intron
     '''
-    gfh = open(gtf, "rU")
+    gfh = openru(gtf)
     genes = {}
     for line in gfh:
         fields = line.strip().split('\t')
@@ -257,7 +264,7 @@ def makeGeneTreeFromExons(gtf, pchrom):
         dictionary of interval trees where the key is the chromosome and the
         value is the root of the interval tree
     '''
-    gfh = open(gtf, "rU")
+    gfh = openru(gtf)
     genes = {}
     for line in gfh:
         fields = line.strip().split('\t')
@@ -318,7 +325,7 @@ def getGeneLengthDistribution(gtf, limit=None):
     Output:
         png file of the histogram named glen.png in the current directory
     '''
-    gfh = open(gtf, "rU")
+    gfh = openru(gtf)
     genes = {}
     for line in gfh:
         fields = line.strip().split('\t')
@@ -364,7 +371,7 @@ def makeTreeFromBed(bed):
         a dictionary is returned where the keys are chromosomes and the values
         are the roots of the interval overlap trees by chromosome.
     '''
-    bfh = open(bed, 'rU')
+    bfh = openru(bed)
     roots = {}
     for line in bfh:
         fields = line.strip().split('\t')

--- a/murphy/parsegtf.py
+++ b/murphy/parsegtf.py
@@ -31,11 +31,13 @@ from murphy.Tree import intervalTree
 
 matplotlib.style.use('ggplot')
 
+
 def openru(f):
     if six.PY2:
         return open(f, "rU")
     else:
         return open(f, newline=None)
+
 
 def getKeySort(item):
     '''

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="murphy",
-    version="0.1",
+    version="0.1.1",
     packages=find_packages(),
     package_data={
         "": ["*.txt", "*.rst", ],
@@ -43,7 +43,10 @@ overlaps with the search interval.  The search routine is also recursive.
                  "Topic :: Scientific/Engineering :: Bio-Informatics",
                  ],
     zip_safe=False,
-    install_requires=["matplotlib", ],
+    install_requires=["six",
+                      "numpy",
+                      "matplotlib",
+                      ],
     test_suite="nose.collector",
     tests_require=["nose", ]
 )


### PR DESCRIPTION
open(gtf, "rU") was raising a deprecation warning in parsegtf.py because "U" has been removed as a valid open mode in Python 3 and replaced with a keyword argument "newline" (which when set to None, as it is by default, will cause universal newline support). I used six to detect the python version in a wrapped version of open I called openru and call the correct incantation of open with universal newline support.